### PR TITLE
Fix pdf/cdf calls

### DIFF
--- a/src/landau.jl
+++ b/src/landau.jl
@@ -55,10 +55,9 @@ params(d::Landau) = (d.μ, d.θ)
 @inline partype(d::Landau{T}) where {T<:Real} = T
 
 #### Evaluation
+pdf(d::Landau, x::Real) = _landau_pdf(x, d.μ, d.θ)
 
-pdf(d::Landau, x::Real) = _landau_pdf((x - d.μ) / d.θ)
-
-cdf(d::Landau, x::Real) = _landau_cdf((x - d.μ) / d.θ)
+cdf(d::Landau, x::Real) = _landau_cdf(x, d.μ, d.θ)
 
 function cf(d::Landau, t::Real)
     z = t * (d.μ + d.θ * (sign(t) * im - twoinvπ * log(abs(t))))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,14 @@
 using LandauDistribution
+using Distributions
 using Test
 
 @testset "LandauDistribution.jl" begin
-    # Write your tests here.
+    @test_throws ArgumentError Landau(-1, 0)
+
+    @test pdf(Landau(1, 1), 1) ≈ 0.178854161
+    @test pdf(Landau(1, 2), 3) ≈ 0.145206637
+
+    @test cdf(Landau(1, 2), 1000000000) ≈ 1
+    @test cdf(Landau(3, 4), 1000000000) ≈ 1
+    @test cdf(Landau(5, 6), 1000000000) ≈ 1
 end


### PR DESCRIPTION
The `_landau_pdf()` and `_landau_cdf()` functions are already implemented as PDF/CDF, so I think that e.g.

https://github.com/JuliaHEP/LandauDistribution.jl/blob/6ac7cfe4f797f10048c8970231b8571a84c4c157/src/landau.jl#L59

is colliding with

https://github.com/JuliaHEP/LandauDistribution.jl/blob/6ac7cfe4f797f10048c8970231b8571a84c4c157/src/landau.jl#L100

and messes up the normalisation.

See here (`xi` and `x0` correspond to `d.μ` and `d.θ`):

**Before**

![Screenshot 2021-09-16 at 10 23 09](https://user-images.githubusercontent.com/1730350/133577575-c066c311-8231-4dfc-9db6-a0c25b7c6729.png)

**After**

![Screenshot 2021-09-16 at 10 24 16](https://user-images.githubusercontent.com/1730350/133577640-b4cd6b28-e385-4a5d-a07e-c073409b289f.png)