### PR TITLE
Fix constructor: add new method for Integer arguments

### DIFF
--- a/src/landau.jl
+++ b/src/landau.jl
@@ -34,6 +34,7 @@ struct Landau{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 Landau(μ::Real, θ::Real; check_args=true) = Landau(promote(μ, θ)...; check_args=check_args)
+Landau(μ::Integer, θ::Integer; check_args=true) = Landau(float(μ), float(θ); check_args=check_args)
 Landau(μ::Real=0) = Landau(μ, one(μ); check_args=false)
 
 @distr_support Landau -Inf Inf


### PR DESCRIPTION
Add a new constructor method for Integer to fix `InexactError`

```julia
julia> L = Landau()
Landau{Int64}(μ=0, θ=1)

julia> rand(L)
ERROR: InexactError: Int64(0.7536428655650418)
...
```

Ported from [Distribution.jl's `Normal` constructor](https://github.com/JuliaStats/Distributions.jl/blob/dd876e7525cd206a5cafd9165a956ac95c2b7b39/src/univariate/continuous/normal.jl#L43).